### PR TITLE
[Feat] : postgre sql to qdrant connection settings

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -10,7 +10,20 @@ class Settings(BaseSettings):
     QDRANT_API_KEY: str
     QDRANT_COLLECTION: str = "feedback_current" # .env에 값이 없으면 이 기본값을 사용
 
-     # 앞으로 추가될 다른 설정들...
+    # PostgreSQL
+    POSTGRES_DSN: str
+
+    # Redis
+    REDIS_URL: str | None = None  # 선택적, 없으면 None 처리
+
+    # pydantic 설정
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore"
+    )
+
+    # 앞으로 추가될 다른 설정들...
     # PG_URL: str
     # REDIS_URL: str
     # ANTHROPIC_API_KEY: str

--- a/tests/delete_qdrant_collection.py
+++ b/tests/delete_qdrant_collection.py
@@ -1,0 +1,18 @@
+from qdrant_client import QdrantClient
+from core.config import settings
+
+client = QdrantClient(
+    url=settings.QDRANT_URL,
+    api_key=settings.QDRANT_API_KEY
+)
+
+# 삭제할 컬렉션 이름
+target_collection = settings.QDRANT_COLLECTION  # 보통 "feedback_current"
+
+# 컬렉션 삭제
+client.delete_collection(collection_name=target_collection)
+
+print(f"컬렉션 '{target_collection}' 완전히 삭제 완료!")
+
+
+#python -m tests.delete_qdrant_collection

--- a/tests/test_connectivity_checks.py
+++ b/tests/test_connectivity_checks.py
@@ -1,0 +1,237 @@
+# === PostgreSQL 연결 + Qdrant 기본 동작 + search_corpus→임베딩→Qdrant 업서트 E2E 스모크 테스트 ===
+from __future__ import annotations
+from typing import List, Dict, Tuple, Optional
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+from qdrant_client import models
+from core.config import settings
+from infra.qdrant import (
+    client,
+    initialize_qdrant,
+    upsert_points,
+    delete_collection,
+)
+from workers.embedder import embed_batch
+
+
+# ------------------------------------------------------------
+# 환경/설정
+# ------------------------------------------------------------
+# 🔹 네가 준 DB 하드코딩
+DB_CONFIG = {
+    "dbname":   "pre_capstone",
+    "user":     "pre_capstone",
+    "password": "pre_capstone1234!",
+    "host":     "34.50.13.135",
+    "port":     "5432",
+}
+
+# 🔹 테스트 컬렉션 (운영 오염 방지용)
+TEST_COLLECTION = f"{settings.QDRANT_COLLECTION}_smoke"
+
+# 🔹 search_corpus에서 가져올 SQL (id/title/body/category/updated_at 필수)
+SQL_FETCH_ONE = """
+    SELECT id, title, body, category, updated_at
+    FROM public.search_corpus
+    ORDER BY id
+    LIMIT %s
+"""
+
+# 🔹 llm_outputs 존재 가정 (이미 생성되어 있음)
+SQL_HAS_LLM = "SELECT 1 FROM public.llm_outputs WHERE source_id = %s"
+SQL_PUT_LLM  = """
+INSERT INTO public.llm_outputs (source_id, normalized, llm_version)
+VALUES (%s, %s, %s)
+ON CONFLICT (source_id) DO NOTHING
+"""
+
+KEEP_TEST_COLLECTION = False   # True면 컬렉션 유지, False면 마지막에 삭제
+
+
+# ------------------------------------------------------------
+# 유틸
+# ------------------------------------------------------------
+def call_llm_normalize(title: str, body: str) -> Tuple[str, str]:
+    """(임시 스텁) 최초 질의인 경우 LLM이 가공한 텍스트라고 가정."""
+    normalized = f"{title}\n{body}"
+    llm_version = "stub-0"
+    return normalized, llm_version
+
+def choose_text_for_embedding(cur, row: Dict) -> Tuple[str, str, Optional[str]]:
+    """
+    PM 규칙 반영:
+        - 최초 질의: llm_outputs에 없으면 LLM 호출 → normalized 저장 → 이번엔 LLM 텍스트로 임베딩 (source='llm')
+        - 재질의: llm_outputs에 있으면 DB 정규화 텍스트로 임베딩 (source='db')
+    """
+    cur.execute(SQL_HAS_LLM, (row["id"],))
+    seen = cur.fetchone() is not None
+
+    if seen:
+        text = f"{row['title']}\n{row['body']}"
+        return text, "db", None
+    else:
+        normalized, llm_ver = call_llm_normalize(row["title"], row["body"])
+        cur.execute(SQL_PUT_LLM, (row["id"], normalized, llm_ver))
+        return normalized, "llm", llm_ver
+
+
+# ------------------------------------------------------------
+# 체크/테스트 함수
+# ------------------------------------------------------------
+def check_postgres():
+    print("[PG] 연결 시도…")
+    conn = psycopg2.connect(**DB_CONFIG)
+    cur = conn.cursor(cursor_factory=RealDictCursor)
+
+    cur.execute("SELECT now() AS now_utc")
+    print(f"[OK] postgres now() = {cur.fetchone()['now_utc']}")
+
+    cur.execute("""
+        SELECT table_schema, table_name
+        FROM information_schema.tables
+        WHERE table_schema = 'public'
+        ORDER BY table_name
+        LIMIT 10
+    """)
+    rows = cur.fetchall()
+    names = [f"{r['table_schema']}.{r['table_name']}" for r in rows]
+    print(f"[OK] public 스키마 테이블 예시: {names}")
+
+    cur.close()
+    conn.close()
+
+
+def check_qdrant_basic():
+    print("[Qdrant] 연결/컬렉션 보장…")
+    initialize_qdrant(TEST_COLLECTION)
+    print("[OK] 테스트 컬렉션 준비 완료")
+
+    # 업서트 → retrieve → 삭제 (필터 인덱스 없이도 통과)
+    test_id = 999_999_999
+    p = models.PointStruct(
+        id=test_id,
+        vector=[0.0] * 1024,
+        payload={"smoke": True, "note": "connectivity-check"},
+    )
+    upsert_points([p], collection_name=TEST_COLLECTION)
+    print("[OK] upsert 1건")
+
+    got = client.retrieve(
+        collection_name=TEST_COLLECTION,
+        ids=[test_id],
+        with_payload=True,
+        with_vectors=False,
+    )
+    assert len(got) == 1, "retrieve 결과 0건"
+    assert got[0].payload.get("smoke") is True, "payload.smoke != True"
+    print("[OK] retrieve 확인")
+
+    client.delete(
+        collection_name=TEST_COLLECTION,
+        points_selector=models.PointIdsList(points=[test_id]),
+    )
+    print("[OK] cleanup (delete 1건)")
+
+
+def test_ingest_small_sample(limit: int = 5):
+    """
+    search_corpus에서 소량 가져와 임베딩 후 TEST_COLLECTION에 업서트 → 하나 임의 조회 확인.
+    """
+    print(f"[E2E] search_corpus → 임베딩 → Qdrant 업서트 (limit={limit})")
+
+    # 1) 테스트 컬렉션 보장
+    initialize_qdrant(TEST_COLLECTION)
+
+    # 2) PG 연결/조회
+    conn = psycopg2.connect(**DB_CONFIG)
+    cur = conn.cursor(cursor_factory=RealDictCursor)
+    print("[PG] 연결 성공")
+
+    cur.execute(SQL_FETCH_ONE, (limit,))
+    rows = cur.fetchall()
+    assert rows, "search_corpus에서 레코드를 가져오지 못했음"
+    print(f"[PG] fetched {len(rows)} rows")
+
+    # 3) PM 규칙에 따라 임베딩 소스 텍스트/메타 정리
+    texts: List[str] = []
+    metas: List[Dict] = []
+    for r in rows:
+        text, source_flag, llm_ver = choose_text_for_embedding(cur, r)
+        conn.commit()  # llm_outputs INSERT 반영
+
+        metas.append({
+            "id": int(r["id"]),
+            "title": r["title"],
+            "category": r.get("category"),
+            "updated_at": str(r.get("updated_at")),
+            "source": source_flag,
+            "llm_version": llm_ver,
+            "embedding_version": "kure-v1",
+        })
+        texts.append(text)
+
+    # 4) 임베딩
+    vecs = embed_batch(texts)
+
+    # 5) Qdrant 포인트 구성
+    points: List[models.PointStruct] = []
+    for meta, vec in zip(metas, vecs):
+        points.append(
+            models.PointStruct(
+                id=meta["id"],
+                vector=vec,
+                payload={
+                    "pg_id": meta["id"],
+                    "title": meta["title"],
+                    "category": meta["category"],
+                    "updated_at": meta["updated_at"],
+                    "source": meta["source"],
+                    "llm_version": meta["llm_version"],
+                    "embedding_version": meta["embedding_version"],
+                },
+            )
+        )
+
+    # 6) 업서트
+    upsert_points(points, collection_name=TEST_COLLECTION)
+    print(f"[OK] upsert {len(points)}건")
+
+    # 7) 카운트/샘플 조회 확인
+    total_cnt = client.count(TEST_COLLECTION, exact=True).count
+    print(f"[OK] 테스트 컬렉션 전체 개수: {total_cnt}")
+
+    sample_id = metas[0]["id"]
+    got = client.retrieve(
+        collection_name=TEST_COLLECTION,
+        ids=[sample_id],
+        with_payload=True,
+        with_vectors=False,
+    )
+    assert len(got) == 1, f"retrieve 실패 (id={sample_id})"
+    payload = got[0].payload or {}
+    print(f"[OK] 샘플(payload): id={sample_id}, source={payload.get('source')}, title={payload.get('title')!r}")
+
+    cur.close()
+    conn.close()
+    print("[PG] 연결 종료")
+
+
+# ------------------------------------------------------------
+# main
+# ------------------------------------------------------------
+if __name__ == "__main__":
+    print("Settings loaded successfully!")
+    print(f"Qdrant URL: {settings.QDRANT_URL}")
+    print("=== SMOKE TESTS START ===")
+    try:
+        check_postgres()            # 1) PG 붙는지/테이블 보이는지
+        check_qdrant_basic()        # 2) Qdrant에 쓰기/읽기/삭제 동작 확인(테스트 컬렉션)
+        test_ingest_small_sample(5) # 3) 실제 search_corpus→임베딩→Qdrant 업서트 확인(5건)
+
+        print("=== SMOKE TESTS OK ===")
+    finally:
+        if not KEEP_TEST_COLLECTION:
+            print(f"[CLEANUP] 테스트 컬렉션 삭제: {TEST_COLLECTION}")
+            delete_collection(TEST_COLLECTION)

--- a/workers/embedder.py
+++ b/workers/embedder.py
@@ -1,49 +1,110 @@
-from sentence_transformers import SentenceTransformer
+# from sentence_transformers import SentenceTransformer
 
-# 1. 한국어 특화 임베딩 모델 로드
-# - 모델명: "nlpai-lab/KURE-v1"
-# - 벡터 차원: 1024
-model = SentenceTransformer("nlpai-lab/KURE-v1") 
+# # 1. 한국어 특화 임베딩 모델 로드
+# # - 모델명: "nlpai-lab/KURE-v1"
+# # - 벡터 차원: 1024
+# model = SentenceTransformer("nlpai-lab/KURE-v1") 
 
-def get_embedding(text: str) -> list[float]:
-    """
-    텍스트를 받아 문장 임베딩 생성
-    - 반환값: list[float], 차원: 1024
-    """
+# def get_embedding(text: str) -> list[float]:
+#     """
+#     텍스트를 받아 문장 임베딩 생성
+#     - 반환값: list[float], 차원: 1024
+#     """
 
-    # 2. 문장 임베딩 생성
-    embedding = model.encode(text)
+#     # 2. 문장 임베딩 생성
+#     embedding = model.encode(text)
 
-    # 3. 리스트 형태로 반환
-    return embedding.tolist()
+#     # 3. 리스트 형태로 반환
+#     return embedding.tolist()
 
     
 
-"""
-# 토크나이저와 모델을 직접 사용하여 임베딩 생성한 버전
+# """
+# # 토크나이저와 모델을 직접 사용하여 임베딩 생성한 버전
 
-from transformers import AutoTokenizer, AutoModel
-import torch
+# from transformers import AutoTokenizer, AutoModel
+# import torch
 
-# KURE-v1 토크나이저와 모델 로드 (모델명 업데이트)
-tokenizer = AutoTokenizer.from_pretrained("nlpai-lab/KURE-v1")
-model = AutoModel.from_pretrained("nlpai-lab/KURE-v1")
+# # KURE-v1 토크나이저와 모델 로드 (모델명 업데이트)
+# tokenizer = AutoTokenizer.from_pretrained("nlpai-lab/KURE-v1")
+# model = AutoModel.from_pretrained("nlpai-lab/KURE-v1")
 
-# 임베딩 생성 함수
-def get_embedding(text):
-    # 1. 텍스트를 모델 입력용 토큰 시퀀스로 변환
-    # - return_tensors="pt": PyTorch 텐서로 반환
-    # - truncation=True: 모델 최대 입력 길이를 초과하면 자름
-    inputs = tokenizer(text, return_tensors="pt", truncation=True)
+# # 임베딩 생성 함수
+# def get_embedding(text):
+#     # 1. 텍스트를 모델 입력용 토큰 시퀀스로 변환
+#     # - return_tensors="pt": PyTorch 텐서로 반환
+#     # - truncation=True: 모델 최대 입력 길이를 초과하면 자름
+#     inputs = tokenizer(text, return_tensors="pt", truncation=True)
 
-    # 2. 학습이 아닌 추론 단계이므로 gradient 계산 비활성화
-    with torch.no_grad():
-        # 3. 토큰화된 입력 값을 모델에 넣어 각 토큰의 의미 벡터 생성
-        outputs = model(**inputs)
+#     # 2. 학습이 아닌 추론 단계이므로 gradient 계산 비활성화
+#     with torch.no_grad():
+#         # 3. 토큰화된 입력 값을 모델에 넣어 각 토큰의 의미 벡터 생성
+#         outputs = model(**inputs)
 
-    # 4. 토큰 벡터들의 평균 값으로 문장 임베딩 생성
-    embedding = outputs.last_hidden_state.mean(dim=1)
+#     # 4. 토큰 벡터들의 평균 값으로 문장 임베딩 생성
+#     embedding = outputs.last_hidden_state.mean(dim=1)
 
-    # 5. 임베딩을 1차원 리스트 형태로 변환하여 반환
-    return embedding.squeeze().tolist()
-"""
+#     # 5. 임베딩을 1차원 리스트 형태로 변환하여 반환
+#     return embedding.squeeze().tolist()
+# """
+
+
+from __future__ import annotations
+from typing import List, Iterable, Optional
+from sentence_transformers import SentenceTransformer
+import threading
+
+# 모델 로드를 한 번만 수행하기 위한 락
+__model_lock = threading.Lock()
+__model: Optional[SentenceTransformer] = None
+
+def _get_model() -> SentenceTransformer:
+    """
+    내부용: 전역 모델을 lazy-init으로 한 번만 로드.
+    """
+    global __model
+    if __model is None:
+        with __model_lock:
+            if __model is None:
+                m = SentenceTransformer("nlpai-lab/KURE-v1")
+                # 긴 입력이 잘리는 문제를 줄이기 위한 설정(필요 시 조정)
+                # KURE 계열 max_seq_length 기본은 256~512 수준일 수 있음
+                # 너희 데이터 길이에 맞게 256/384/512 등으로 조정 가능
+                m.max_seq_length = 256
+                __model = m
+    return __model
+
+def embed_one(text: str) -> List[float]:
+    """
+    단일 텍스트를 1024차원 임베딩으로 변환.
+    코사인 유사도 사용을 가정하므로 정규화(normalize_embeddings=True) 적용.
+    """
+    model = _get_model()
+    vec = model.encode([text], normalize_embeddings=True)[0]
+    return vec.tolist()
+
+def embed_batch(texts: Iterable[str]) -> List[List[float]]:
+    """
+    여러 텍스트를 배치로 임베딩.
+    - 입력: Iterable[str]
+    - 출력: List[List[float]] (각각 1024차원)
+    """
+    texts_list = list(texts)
+    if not texts_list:
+        return []
+    model = _get_model()
+    vecs = model.encode(texts_list, normalize_embeddings=True)
+    # sentence-transformers는 ndarray 반환 → Python list로 변환
+    return [v.tolist() for v in vecs]
+
+# 선택: 길이 파라미터/디바이스 변경 헬퍼 (필요할 때만 사용)
+def configure(max_seq_length: Optional[int] = None, device: Optional[str] = None) -> None:
+    """
+    런타임에 임베더 설정을 조정하고 싶을 때 사용.
+    예) configure(max_seq_length=384, device='cuda')
+    """
+    model = _get_model()
+    if max_seq_length is not None:
+        model.max_seq_length = int(max_seq_length)
+    if device is not None:
+        model.to(device)

--- a/workers/ingest_pg_to_qdrant.py
+++ b/workers/ingest_pg_to_qdrant.py
@@ -1,0 +1,241 @@
+# """
+# 역할	                        주된 책임	                                파일
+# 데이터 수집기 (ETL)	  PostgreSQL에서 텍스트 데이터를 SELECT로 가져오기	workers/ingest_pg_to_qdrant.py
+# 임베딩 유틸	          텍스트 → 1024차원 KURE-v1 벡터로 변환	                   workers/embedder.py
+# 벡터 저장소 연동기	   Qdrant 컬렉션 생성, 업서트, 검색 등 관리	         infra/qdrant.py 
+# """
+
+# from typing import List, Dict
+# import psycopg2
+# from psycopg2.extras import RealDictCursor
+# from workers.embedder import embed_batch
+# from qdrant_client import models
+
+# # Qdrant/설정 코드 재사용 
+# # 만약 같은 파일에 있다면 import 대신 그대로 호출해도 됨.
+# from core.config import settings
+# from infra.qdrant import initialize_qdrant, upsert_points  
+
+# # ----- PostgreSQL 접속 정보 -----
+# DB_CONFIG = {
+#     "dbname":   "pre_capstone",
+#     "user":     "pre_capstone",
+#     "password": "pre_capstone1234!",
+#     "host":     "34.50.13.135",
+#     "port":     "5432",
+# }
+
+# # 필수: id(정수 PK), title(TEXT), body(TEXT) 는 있어야 아래 로직 그대로 사용 가능
+# SQL_FETCH = """
+#     SELECT id, title, body, category, updated_at
+#     FROM public.search_corpus
+#     WHERE id > %s
+#     ORDER BY id
+#     LIMIT %s
+# """
+
+# # 배치 크기
+# BATCH = 256 
+
+
+# def rows_to_points(rows: List[Dict]) -> List[models.PointStruct]:
+#     texts = [f"{r['title']}\n{r['body']}" for r in rows]
+#     vecs = embed_batch(texts)
+#     points: List[models.PointStruct] = []
+#     for r, v in zip(rows, vecs):
+#         points.append(
+#             models.PointStruct(
+#                 id=int(r["id"]),      # Qdrant 포인트 ID = PG PK
+#                 vector=v,
+#                 payload={
+#                     "pg_id": int(r["id"]),
+#                     "title": r["title"],
+#                     "category": r.get("category"),
+#                     "updated_at": str(r.get("updated_at")),
+#                 },
+#             )
+#         )
+#     return points
+
+# def run():
+#     # 0) Qdrant 컬렉션 보장
+#     initialize_qdrant(settings.QDRANT_COLLECTION)
+
+#     # 1) PG 연결
+#     conn = psycopg2.connect(**DB_CONFIG)
+#     cur = conn.cursor(cursor_factory=RealDictCursor)
+#     print("PostgreSQL 연결 성공")
+
+#     try:
+#         last_id = 0
+#         total = 0
+#         while True:
+#             cur.execute(SQL_FETCH, (last_id, BATCH))
+#             rows = cur.fetchall()
+#             if not rows:
+#                 break
+
+#             points = rows_to_points(rows)
+#             upsert_points(points, collection_name=settings.QDRANT_COLLECTION)
+
+#             last_id = rows[-1]["id"]
+#             total += len(rows)
+#             print(f"indexed so far: {total}")
+
+#         print(f"done. total indexed: {total}")
+
+#     finally:
+#         cur.close()
+#         conn.close()
+#         print("PostgreSQL 연결 종료")
+
+# if __name__ == "__main__":
+#     run()
+
+
+
+from __future__ import annotations
+from typing import List, Dict, Tuple
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+from qdrant_client import models
+from workers.embedder import embed_batch
+from core.config import settings
+from infra.qdrant import initialize_qdrant, upsert_points
+
+
+# ----- PostgreSQL 접속 정보 -----
+DB_CONFIG = {
+    "dbname":   "pre_capstone",
+    "user":     "pre_capstone",
+    "password": "pre_capstone1234!",
+    "host":     "34.50.13.135",
+    "port":     "5432",
+}
+
+# 원본 소스 뷰/테이블 (정규화된 DB 텍스트가 여기서 나온다고 가정)
+SQL_FETCH = """
+    SELECT id, title, body, category, updated_at
+    FROM public.search_corpus
+    WHERE id > %s
+    ORDER BY id
+    LIMIT %s
+"""
+
+
+# LLM 처리 여부 확인/조회/저장
+SQL_HAS_LLM = "SELECT 1 FROM public.llm_outputs WHERE source_id = %s"
+SQL_GET_LLM  = "SELECT normalized, llm_version FROM public.llm_outputs WHERE source_id = %s"
+SQL_PUT_LLM  = "INSERT INTO public.llm_outputs (source_id, normalized, llm_version) VALUES (%s, %s, %s) ON CONFLICT (source_id) DO NOTHING"
+
+# 배치 크기
+BATCH = 256
+
+# ---- (임시) LLM 호출 스텁 ----
+# 실제로는 workers/llm_extractor.py의 함수를 불러 LLM 호출/스키마 검증을 수행하면 됨.
+# 여기서는 파이프라인을 맞추기 위해 title+body를 그대로 normalized로 반환.
+def call_llm_normalize(title: str, body: str) -> Tuple[str, str]:
+    # TODO: 실제 LLM 연동으로 교체
+    normalized = f"{title}\n{body}"
+    llm_version = "stub-0"  # 프롬프트/모델 버전 명시
+    return normalized, llm_version
+
+def choose_text_for_embedding(cur, row: Dict) -> Tuple[str, str, str | None]:
+    """
+    규칙:
+    - 최초 질의: llm_outputs에 없으면 LLM 호출 → normalized 저장 → 이번엔 LLM 텍스트로 임베딩 (source='llm')
+    - 재질의: llm_outputs에 있으면 DB 정규화 텍스트로 임베딩 (source='db')
+    반환: (embedding_text, source_flag, llm_version_or_None)
+    """
+    # LLM 처리 이력 있는지 확인
+    cur.execute(SQL_HAS_LLM, (row["id"],))
+    seen = cur.fetchone() is not None
+
+    if seen:
+        # 재질의: DB 직행
+        text = f"{row['title']}\n{row['body']}"
+        return text, "db", None
+    else:
+        # 최초 질의: LLM 경로
+        normalized, llm_ver = call_llm_normalize(row["title"], row["body"])
+        cur.execute(SQL_PUT_LLM, (row["id"], normalized, llm_ver))
+        return normalized, "llm", llm_ver
+    
+def run():
+    # 0) Qdrant 컬렉션 보장
+    initialize_qdrant(settings.QDRANT_COLLECTION)
+
+    # 1) PG 연결
+    conn = psycopg2.connect(**DB_CONFIG)
+    cur = conn.cursor(cursor_factory=RealDictCursor)
+    print("PostgreSQL 연결 성공")
+
+    try:
+        last_id = 0
+        total = 0
+
+        while True:
+            cur.execute(SQL_FETCH, (last_id, BATCH))
+            rows = cur.fetchall()
+            if not rows:
+                break
+
+            # 규칙에 맞춰 임베딩 입력 텍스트/메타 결정
+            texts: List[str] = []
+            metas: List[Dict] = []
+            for r in rows:
+                text, source_flag, llm_ver = choose_text_for_embedding(cur, r)
+                # llm_outputs INSERT 반영
+                conn.commit()
+
+                texts.append(text)
+                metas.append({
+                    "id": int(r["id"]),
+                    "title": r["title"],
+                    "category": r.get("category"),
+                    "updated_at": str(r.get("updated_at")),
+                    "source": source_flag,
+                    "llm_version": llm_ver,
+                    "embedding_version": "kure-v1",
+                })
+
+            # 3) 임베딩
+            vecs = embed_batch(texts)
+
+            # 4) Qdrant 포인트 구성
+            points: List[models.PointStruct] = []
+            for meta, vec in zip(metas, vecs):
+                points.append(
+                    models.PointStruct(
+                        id=meta["id"],          # 동일 id에 upsert → 이후 실행에서 DB버전으로 덮어씀
+                        vector=vec,
+                        payload={
+                            "pg_id": meta["id"],
+                            "title": meta["title"],
+                            "category": meta["category"],
+                            "updated_at": meta["updated_at"],
+                            "source": meta["source"],                   # 'llm' or 'db'
+                            "llm_version": meta["llm_version"],
+                            "embedding_version": meta["embedding_version"],
+                        },
+                    )
+                )
+
+            # 5) 업서트
+            upsert_points(points, collection_name=settings.QDRANT_COLLECTION)
+
+            last_id = rows[-1]["id"]
+            total += len(rows)
+            print(f"indexed so far: {total}")
+
+        print(f"done. total indexed: {total}")
+
+    finally:
+        cur.close()
+        conn.close()
+        print("PostgreSQL 연결 종료")
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
관련 이슈
https://github.com/pmi-4team/embedding-engineering/issues/6

구현한 것
ingest_pg_to_qdrant.py
test_connectivity_checks.py
delete_qdrant_collection.py
수정한 것
config.py
qdrant.py
embedder.py
"/workers/ingest_pg_to_qdrant.py" 파일에서 qdrant.py와 embedder.py를 사용해 하드코딩된 DB_CONFIG 정보로 postgreSQL에 연결

SQL_FETCH로 원본 소스의 뷰를 실행
이때 LLM처리 이력이 있는지 확인 후 처리 이력이 있을 경우엔 바로 DB에서 Qdrant로 다이렉트로 처리
그렇지 않은 경우, DB -> LLM -> 임베딩으로 처리하게끔 로직 작성
주의 사항 : call_llm_normalize 함수는 현재 LLM 호출 스텁으로 llm_extractor.py가 완료되면 refact할 예정